### PR TITLE
🐛 Fix : Bug/2 phone input validation

### DIFF
--- a/src/page/auth/Register.jsx
+++ b/src/page/auth/Register.jsx
@@ -77,10 +77,15 @@ function Register() {
                 })}
               />
               <input
-                type="number"
+                type="tel"
                 placeholder="전화번호"
                 {...register("phoneNumber", {
                   required: "전화번호를 입력해주세요.",
+                  pattern: {
+                    value: /^010\d{7}$/,
+                    message:
+                      "전화번호는 010으로 시작하며 숫자 10자리여야 합니다.",
+                  },
                 })}
               />
             </div>
@@ -90,7 +95,8 @@ function Register() {
                 {errors.email?.message ||
                   errors.password?.message ||
                   errors.passwordCheck?.message ||
-                  errors.nickname?.message}
+                  errors.nickname?.message ||
+                  errors.phoneNumber?.message}
               </p>
               <button
                 type="submit"

--- a/src/page/auth/Register.jsx
+++ b/src/page/auth/Register.jsx
@@ -82,9 +82,9 @@ function Register() {
                 {...register("phoneNumber", {
                   required: "전화번호를 입력해주세요.",
                   pattern: {
-                    value: /^010\d{7}$/,
+                    value: /^010\d{8}$/,
                     message:
-                      "전화번호는 010으로 시작하며 숫자 10자리여야 합니다.",
+                      "전화번호는 010으로 시작하며 숫자 11자리여야 합니다.",
                   },
                 })}
               />


### PR DESCRIPTION
## 🔎 작업 내용
> 회원가입 페이지에서 전화번호 입력칸의 ```type```을 ```tel```로 변경
> 전화번호 입력시 숫자만 포함해야하며 010으로 시작하는 11자리로 입력받도록 유효성 검사 추가

<br/>

## ➕ 이슈 링크

> [이슈링크](https://github.com/daj3on9/KakaoTalk_CloneCoding/issues/2)


<br/>


## 📸 스크린샷

